### PR TITLE
Fix avoid invalid option '%-100' to 'format'

### DIFF
--- a/lua/dap-disasm.lua
+++ b/lua/dap-disasm.lua
@@ -151,7 +151,7 @@ write_buf = function(pc)
       line = line .. string.format(fmts.instructionBytes .. "\t", ins.instructionBytes or "??")
     end
     if fmts.instruction then
-      line = line .. string.format(fmts.instruction, ins.instruction or "??")
+      line = line .. (ins.instruction or "??")
     end
     line = line:gsub("%s+$", "")
     table.insert(lines, line)


### PR DESCRIPTION
For instructions table that contains long comments like this
```
0x55555556C9ED:    callq  0x55555556aaa0  ; core::ptr::drop_in_place<alloc::vec::Vec<alloc::string::String>> at mod.rs:523
```
it crashes with error `invalid option '%-100' to 'format'` here
```
line = line .. string.format(fmts.instruction, ins.instruction or "??")
```
because lua `%-{n}s` works only for `n < 100`.

The fix is pretty straightforward, removed max length calculation and formatting for instruction, because it's always at the end of the line and gsub'ed anyway