### PR TITLE
feat: `dap-view` integration, disable winbar and enable treesitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,15 @@ require("nvim-dap-disasm").setup({
     -- Add disassembly view to elements of nvim-dap-ui
     dapui_register = true,
 
+    -- Add disassembly view to nvim-dap-view
+    dapview_register = true,
+
     -- Add custom REPL commands for stepping with instruction granularity
     repl_commands = true,
+
+    -- Show winbar with buttons to step into the code with instruction granularity
+    -- This settings is overriden (disabled) if the dapview integration is enabled and the plugin is installed
+    winbar = true,
 
     -- The sign to use for instruction the exectution is stopped at
     sign = "DapStopped",

--- a/lua/dap-disasm.lua
+++ b/lua/dap-disasm.lua
@@ -128,7 +128,7 @@ clear = function()
     vim.api.nvim_buf_set_lines(buffer, 0, -1, false, {})
     if not buf_extern then
       local win = vim.fn.bufwinid(buffer)
-      if win and vim.api.nvim_win_is_valid(win) then
+      if win and vim.api.nvim_win_is_valid(win) and M.config.winbar then
         vim.api.nvim_set_option_value("winbar", "", {
             win = win,
             scope = "local",
@@ -241,7 +241,7 @@ M.refresh = function()
     if err then return end
     instructions = res.instructions or {}
     write_buf(pc)
-    if not buf_extern then
+    if M.config.winbar then
       vim.api.nvim_set_option_value("winbar", mk_winbar(), {
           win = win,
           scope = "local",
@@ -291,6 +291,7 @@ end, { nargs = "*" })
 M.config = {
   dapui_register = true,
   repl_commands = true,
+  winbar = true,
   sign = "DapStopped",
   ins_before_memref = nil,
   ins_after_memref = nil,

--- a/lua/dap-disasm.lua
+++ b/lua/dap-disasm.lua
@@ -309,6 +309,8 @@ M.config = {
 }
 
 M.setup = function(conf)
+  vim.treesitter.language.register("disassembly", "dap_disassembly")
+
   M.config = vim.tbl_deep_extend("force", M.config, conf or {})
 
   if M.config.ins_before_memref then

--- a/lua/dap-disasm.lua
+++ b/lua/dap-disasm.lua
@@ -289,6 +289,7 @@ vim.api.nvim_create_user_command("DapDisasmSetMemref", function(t)
 end, { nargs = "*" })
 
 M.config = {
+  dapview_register = true,
   dapui_register = true,
   repl_commands = true,
   winbar = true,
@@ -336,6 +337,17 @@ M.setup = function(conf)
           allow_without_session = false,
         })
     end
+  end
+
+  if M.config.dapview_register and package.loaded["dap-view"] then
+    require("dap-view").register_view("disassembly", {
+      action = M.refresh,
+      buffer = disasm_buf.create,
+      keymap = "D",
+      label = "Disassembly [D]",
+      short_label = "󰚩 [D]",
+      filetype = "dap_disassembly",
+    })
   end
 end
 

--- a/lua/dap-disasm.lua
+++ b/lua/dap-disasm.lua
@@ -349,7 +349,8 @@ M.setup = function(conf)
       buffer = disasm_buf.create,
       keymap = "D",
       label = "Disassembly [D]",
-      short_label = "󰚩 [D]",
+      -- nerd font icon nf-md-cog
+      short_label = "󰒓 [D]",
       filetype = "dap_disassembly",
     })
   end

--- a/lua/dap-disasm.lua
+++ b/lua/dap-disasm.lua
@@ -289,8 +289,8 @@ vim.api.nvim_create_user_command("DapDisasmSetMemref", function(t)
 end, { nargs = "*" })
 
 M.config = {
-  dapview_register = true,
   dapui_register = true,
+  dapview_register = true,
   repl_commands = true,
   winbar = true,
   sign = "DapStopped",
@@ -342,6 +342,8 @@ M.setup = function(conf)
   end
 
   if M.config.dapview_register and package.loaded["dap-view"] then
+    -- disable winbar to avoid conflict with dap-view
+    M.config.winbar = false
     require("dap-view").register_view("disassembly", {
       action = M.refresh,
       buffer = disasm_buf.create,


### PR DESCRIPTION
Closes #2 

<img width="993" height="334" alt="image" src="https://github.com/user-attachments/assets/97ed9e8c-20a0-4355-bb00-5199c7b3cd59" />

I had to add the possibility to disable the winbar, since `dap-view` also uses it. We could think about an alternative approach, by leveraging `dap-view`'s control bar, which serves a similar purpose: I could add a `register_button` function, enabling us to create `step_into_instruction` (etc) buttons, and then we could instruct users to add these buttons to their configurations.