### PR TITLE
Adding configuration options for dap-view section

### DIFF
--- a/lua/dap-disasm.lua
+++ b/lua/dap-disasm.lua
@@ -326,6 +326,12 @@ M.config = {
     "instructionBytes",
     "instruction",
   },
+  dapview = {
+    keymap = "D",
+    label = "Disassembly [D]",
+    -- nerd font icon nf-md-cog
+    short_label = "󰒓 [D]",
+  }
 }
 
 M.setup = function(conf)
@@ -373,10 +379,9 @@ M.setup = function(conf)
     require("dap-view").register_view("disassembly", {
       action = M.refresh,
       buffer = disasm_buf.create,
-      keymap = "D",
-      label = "Disassembly [D]",
-      -- nerd font icon nf-md-cog
-      short_label = "󰒓 [D]",
+      keymap = M.config.dapview.keymap,
+      label = M.config.dapview.label,
+      short_label = M.config.dapview.label,
       filetype = "dap_disassembly",
     })
   end


### PR DESCRIPTION
Quick edit allowing configuration of `keymap`, `label`, and `short_label`, like any other dap-view section.
Another option if you're okay with breaking changes would be to remove `dapview_register` and use the existence of the `dapview` object as the condition for registering the view instead:
```lua
if M.config.dapview and package.loaded["dap-view"] then
  -- Register the view, etc etc
end
```